### PR TITLE
Fix sending general cargo to a ship propellant tank

### DIFF
--- a/src/app/[service]/[asteroidId]/[crewId]/transfer-goods/confirmation-step.tsx
+++ b/src/app/[service]/[asteroidId]/[crewId]/transfer-goods/confirmation-step.tsx
@@ -89,7 +89,7 @@ export const ConfirmationStep = ({
       inventoryId: destination.id,
       inventoryType:
         destination.type === 'ship' ? Entity.IDS.SHIP : Entity.IDS.BUILDING,
-      inventorySlot: destination.type === 'ship' ? 1 : 2,
+      inventorySlot: 2,
     },
     deliveries.map((delivery) => ({
       source: {
@@ -98,7 +98,7 @@ export const ConfirmationStep = ({
           delivery.source.type === 'ship'
             ? Entity.IDS.SHIP
             : Entity.IDS.BUILDING,
-        inventorySlot: delivery.source.type === 'ship' ? 1 : 2,
+        inventorySlot: 2,
         owningCrewId: delivery.source.owningCrewId,
       },
       contents: delivery.contents.filter((c) => c.amount > 0),


### PR DESCRIPTION
General cargo bay is always id 2!

A ship has a prop bay as id 1 and a cargo bay as id2
A warehouse has a cargo bay as id 2

=> always send from 2 to 2 for this service.